### PR TITLE
install postman

### DIFF
--- a/docs/preparation.md
+++ b/docs/preparation.md
@@ -32,7 +32,7 @@ $ npm config get registry
 
 Postman 是一个 HTTP 通信测试工具，REST API 的练习会用到它。
 
-请到官网 [GetPostman.com](https://www.getpostman.com/) 下载独立安装包；也可以参考这篇文章[www.cnblogs.com/mafly/p/postman.html](http://www.cnblogs.com/mafly/p/postman.html)，下载 Chrome 浏览器的插件，它们的效果一样。
+请到官网 [GetPostman.com](https://www.getpostman.com/) 下载独立安装包。
 
 ## 安装示例库
 


### PR DESCRIPTION
chrome 中无法使用postman扩展程序了，不过postman官网下的app可以用。